### PR TITLE
PHP Notice _load_textdomain_just_in_time was called incorrectly

### DIFF
--- a/load.php
+++ b/load.php
@@ -39,10 +39,10 @@ class scbLoad4 {
 			add_action( 'activate_plugin',  array( __CLASS__, 'delayed_activation' ) );
 		}
 
-		if ( did_action( 'plugins_loaded' ) ) {
+		if ( did_action( 'init' ) ) {
 			self::load();
 		} else {
-			add_action( 'plugins_loaded', array( __CLASS__, 'load' ), 9, 0 );
+			add_action( 'init', array( __CLASS__, 'load' ), 9, 0 );
 		}
 	}
 


### PR DESCRIPTION
Fix is to address the following issue in wp-pagenavi
https://github.com/lesterchan/wp-pagenavi/issues/70
Will also require submodule scb to updated within wp-pagenavi